### PR TITLE
Switched from using dart2js to using pub build, output stdout.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,18 @@
 # dart-brunch
-Adds Dart support to [brunch](http://brunch.io).
+Adds Dart support to [brunch](http://brunch.io) via pub (the dart package manager).
+Simply using dart2js failed to properly link dependencies.
+
+## Caveats
+
+This does not work if the path contains a space.
+There seems to be many problems related to spaces on Windows systems in the NodeJS ecosystem, and it would be hard to fix in an app like this.
 
 ## Install dart-brunch
 ```
 npm install --save dart-brunch
 ```
+
+Make sure that pub and dart2js are on your path; please see Dart documentation on how to do this.
 
 ## Configuration
 Dart has a packing system, so brunch need just to call the recompile of the main entry point of your application. So configure your entry point in the brunch-config.js (or .coffee):
@@ -13,9 +21,8 @@ Dart has a packing system, so brunch need just to call the recompile of the main
 
 plugins: {
   dart: {
-    dart_path: "c:\\tools\\dart-sdk\\bin\\dart2js.bat", //yes, yes... I'm using Windows 10
-    source: "web/dart/main.dart",
-    output: "priv/static/js/main.js"
+    source: "web/dart/",
+    output: "priv/static/js/"
   }
 }
 
@@ -32,6 +39,4 @@ watched: [
 
 ## Roadmap
  - Tests on linux (ubuntu)
- - Automatic get dart_path
  - Better documentation
-

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dart-brunch",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Adds Dart support to brunch.",
   "main": "index.js",
   "scripts": {
@@ -23,5 +23,7 @@
     "mocha": "1.2.2",
     "chai": "1.1.0"
   },
-  "homepage": "https://github.com/thluiz/dart-brunch#readme"
+  "homepage": "https://github.com/thluiz/dart-brunch#readme",
+  "dependencies": {
+  }
 }


### PR DESCRIPTION
This change allows the use of things like AngularUI Components and such.
It also addresses some problems related to the way the path was being
obtained in newer versions of Node.

It might be reasonable to add an option to switch between "pub mode" and "dart2js mode", but that is not done in this commit.